### PR TITLE
1. 유저의 턴 정보를 ServerResponse에 담아서 보내기

### DIFF
--- a/src/ClientHandler.java
+++ b/src/ClientHandler.java
@@ -67,41 +67,20 @@ public class ClientHandler implements Runnable {
             ClientAction action = JsonUtil.jsonToAction(actionJson);
 
             if ("shoot".equalsIgnoreCase(action.getAction())) {
-                server.handleShoot(this, action.getTarget());
+                sendResponse(server.handleShoot(this, action.getTarget()));
             } else if ("useAbility".equalsIgnoreCase(action.getAction())) {
                 // 능력 사용 처리 추가 가능
-                handleUseAbility(action.getTarget());
+                sendResponse(server.handleUseAbility(this,action.getTarget()));
             }
+
+
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
     // 능력 사용 처리
-    private void handleUseAbility(String targetNickname) {
-        try {
-            if (character == null) {
-                sendMessage("캐릭터가 설정되지 않았습니다.");
-                return;
-            }
 
-            // 타겟을 찾음
-            ClientHandler target = server.clients.stream()
-                    .filter(client -> client.getNickname().equals(targetNickname))
-                    .findFirst()
-                    .orElse(null);
-
-            if (target != null) {
-                character.useAbility(target.getCharacter());
-                sendMessage("능력을 사용했습니다: " + character.getInfo());
-            } else {
-                character.useAbility();
-                sendMessage("능력을 사용했습니다: " + character.getInfo());
-            }
-        } catch (Exception e) {
-            sendMessage("능력 사용에 실패했습니다: " + e.getMessage());
-        }
-    }
 
     public void sendMessage(String message) {
         sendResponse(new ServerResponse(message));


### PR DESCRIPTION
: MafiaServer의 sendGameStateToClients() 메소드
2. ServerResponse 변경된 클래스에 맞게 MafiaServer handleShoot, handleUserAblility 수정 완료

---handleUseAblity
정상적인 타겟 설정과 능력 사용 시 반환되는 ServerResponse
return new ServerResponse("useAbility", user.getNickname() + "이(가) 능력을 사용했습니다.", collectCharacters(), gun.getChambers(), currentRound, currentTurnIndex);

---handleShoot
정상적인 타겟 설정시 반환되는 ServerResponse
return new ServerResponse("shoot",shooter.getNickname() + "이(가) " + (hit ? targetNickname + "을(를) 적중시켰습니다." : "빗맞췄습니다."),collectCharacters(), gun.getChambers(), currentRound, currentTurnIndex);

collectCharacters -> List<CharacterTemplate> 반환 메소드입니다! ClientHandler의 StartTurn이
sendResponse(server.handleShoot(this, action.getTarget())); 이런식으로 결과를 바로 담아 전송합니다.

추가 수정사항 있으면 카톡 부탁드립니다!